### PR TITLE
Add `prepublishOnly` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint": "tslint --config tslint.json --project tsconfig.json",
     "test": "mocha --exit --recursive 'test/**/*.test.ts'",
     "build": "tsc",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "prepublishOnly": "npm run build"
   },
   "files": [
     "dist/src/",


### PR DESCRIPTION
Add `prepublishOnly` script to build the package before publishing. See https://github.com/atixlabs/hardhat-time-n-mine/issues/5 for the reason to add this.